### PR TITLE
Remove leftover Compare2 compile item

### DIFF
--- a/CustoComparer/CrmConnectionTool/CrmConnectionTool.csproj
+++ b/CustoComparer/CrmConnectionTool/CrmConnectionTool.csproj
@@ -240,7 +240,6 @@
     <Reference Include="System.Xml.XmlDocument" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Compare2.cs" />
     <Compile Include="CompareFormCustomization.cs" />
     <Compile Include="ManageUser.cs" />
     <Compile Include="Program.cs" />


### PR DESCRIPTION
## Summary
- clean up CrmConnectionTool project file by removing the unused `Compare2.cs` entry

## Testing
- `xbuild CustoComparer/CrmConnectionTool.sln` *(fails: Type and identifier are both required in a foreach statement)*
- `dotnet build CustoComparer/CrmConnectionTool.sln` *(fails: reference assemblies for .NETFramework,Version=v4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e64230768833387de5dfbe232e81a