### PR TITLE
Fix CompareFormTool target and docs

### DIFF
--- a/CustoComparer/CompareFormTool/CompareFormTool.csproj
+++ b/CustoComparer/CompareFormTool/CompareFormTool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/CustoComparer/CompareFormTool/Program.cs
+++ b/CustoComparer/CompareFormTool/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace CompareFormTool
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("CompareFormTool placeholder");
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# D365 CustoComparer
+
+This repository contains tools for comparing customizations in Dynamics 365.  
+The `CrmConnectionTool` project targets .NET Framework 4.8 and provides the existing Windows Forms tooling.  
+
+`CompareFormTool` is a placeholder console project that may evolve into a modern .NET implementation. It currently targets **.NET 6** so it can be compiled with stable tooling. The project only prints a placeholder message.
+


### PR DESCRIPTION
## Summary
- set CompareFormTool to .NET 6 and add minimal `Program.cs`
- add repository README

## Testing
- `dotnet build CustoComparer/CompareFormTool/CompareFormTool.csproj`
- `dotnet build CustoComparer/CrmConnectionTool.sln` *(fails: reference assemblies for .NETFramework,Version=v4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e646492fc8333a5014f014f6de561