### PR TITLE
Fix DocumentFormat.OpenXml version

### DIFF
--- a/CustoComparer/CrmConnectionTool/CrmConnectionTool.csproj
+++ b/CustoComparer/CrmConnectionTool/CrmConnectionTool.csproj
@@ -238,7 +238,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="DocumentFormat.OpenXml">
-      <HintPath>..\packages\DocumentFormat.OpenXml.2.19.1\lib\net46\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\packages\DocumentFormat.OpenXml.2.19.0\lib\net46\DocumentFormat.OpenXml.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.XmlDocument" />
   </ItemGroup>

--- a/CustoComparer/CrmConnectionTool/packages.config
+++ b/CustoComparer/CrmConnectionTool/packages.config
@@ -51,6 +51,6 @@
   <package id="System.Text.Encodings.Web" version="9.0.6" targetFramework="net48" />
   <package id="System.Text.Json" version="9.0.6" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.6.3" targetFramework="net48" />
-  <package id="DocumentFormat.OpenXml" version="2.19.1" targetFramework="net48" />
+  <package id="DocumentFormat.OpenXml" version="2.19.0" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.6.1" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
## Summary
- downgrade DocumentFormat.OpenXml to 2.19.0
- update reference path for the downgraded version

## Testing
- `dotnet msbuild CustoComparer/CrmConnectionTool/CrmConnectionTool.csproj /t:Restore,Build /p:Configuration=Release` *(fails: reference assemblies for .NETFramework,Version=v4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f872a34a483338f106e4ef14ae329